### PR TITLE
fix: explicitly assign problematic portal interfaces (that fallback to gnome) to regolith portal

### DIFF
--- a/data/regolith-portals.conf
+++ b/data/regolith-portals.conf
@@ -1,3 +1,10 @@
 [preferred] 
-default=gtk;regolith;
+default=gtk
 org.freedesktop.impl.portal.Secret=gnome-keyring
+
+org.freedesktop.impl.portal.Background=regolith
+org.freedesktop.impl.portal.Clipboard=regolith
+org.freedesktop.impl.portal.InputCapture=regolith
+org.freedesktop.impl.portal.RemoteDesktop=regolith
+org.freedesktop.impl.portal.Settings=regolith
+org.freedesktop.impl.portal.Wallpaper=regolith

--- a/data/regolith-wayland-portals.conf
+++ b/data/regolith-wayland-portals.conf
@@ -1,3 +1,10 @@
 [preferred] 
-default=wlr;gtk;regolith;
+default=wlr;gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring
+
+org.freedesktop.impl.portal.Background=regolith
+org.freedesktop.impl.portal.Clipboard=regolith
+org.freedesktop.impl.portal.InputCapture=regolith
+org.freedesktop.impl.portal.RemoteDesktop=regolith
+org.freedesktop.impl.portal.Settings=regolith
+org.freedesktop.impl.portal.Wallpaper=regolith


### PR DESCRIPTION
Portals may not follow the expected ordering as per [this](https://github.com/flatpak/xdg-desktop-portal/issues/1111) issue.

This causes some of the interfaces that are made available by other backend (like gtk or wlr) to get assigned to the no-op implementations of the xdp-regolith backend.

This PR explicitly assigns only the problematic interfaces, i.e. the ones that get assigned to xdp-gnome, to the regolith backend.