### PR TITLE
fix: build regression on plucky.  Seems like meson cannot find correc…

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 10),
                libgtk-4-dev,
                meson,
                po-debconf,
-               libsystemd-dev,
+               systemd-dev,
                valac-0.56-vapi,
                valac-bin
 Standards-Version: 4.1.2


### PR DESCRIPTION
…t dependency without updating debian package dependency to slightly different name