### PR TITLE
fix: dark mode not working

### DIFF
--- a/data/regolith-wayland-portals.conf
+++ b/data/regolith-wayland-portals.conf
@@ -1,10 +1,10 @@
 [preferred] 
 default=wlr;gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring
+org.freedesktop.impl.portal.Settings=gtk
 
 org.freedesktop.impl.portal.Background=regolith
 org.freedesktop.impl.portal.Clipboard=regolith
 org.freedesktop.impl.portal.InputCapture=regolith
 org.freedesktop.impl.portal.RemoteDesktop=regolith
-org.freedesktop.impl.portal.Settings=regolith
 org.freedesktop.impl.portal.Wallpaper=regolith


### PR DESCRIPTION
The settings portal `org.freedesktop.impl.portal.Settings` allows applications to read and view system settings, including the preference for dark mode.

It was previously disabled due to conflicts with the gnome portal, causing the waiting time issue for gnome. 

However, `gtk` implements this portal. This PR sets `gtk` as the preferred backend for the settings portal, instead of the no-op regolith version, which brings back the ability to set the dark mode.

Fixes https://github.com/regolith-linux/regolith-desktop/issues/1114