### PR TITLE
use `none` keyword for disabling interfaces

### DIFF
--- a/data/regolith-portals.conf
+++ b/data/regolith-portals.conf
@@ -1,10 +1,9 @@
-[preferred] 
+[preferred]
 default=gtk
 org.freedesktop.impl.portal.Secret=gnome-keyring
 
-org.freedesktop.impl.portal.Background=regolith
-org.freedesktop.impl.portal.Clipboard=regolith
-org.freedesktop.impl.portal.InputCapture=regolith
-org.freedesktop.impl.portal.RemoteDesktop=regolith
-org.freedesktop.impl.portal.Settings=regolith
-org.freedesktop.impl.portal.Wallpaper=regolith
+org.freedesktop.impl.portal.Background=none
+org.freedesktop.impl.portal.Clipboard=none
+org.freedesktop.impl.portal.InputCapture=none
+org.freedesktop.impl.portal.RemoteDesktop=none
+org.freedesktop.impl.portal.Wallpaper=none

--- a/data/regolith-wayland-portals.conf
+++ b/data/regolith-wayland-portals.conf
@@ -1,10 +1,9 @@
-[preferred] 
+[preferred]
 default=wlr;gtk;
 org.freedesktop.impl.portal.Secret=gnome-keyring
-org.freedesktop.impl.portal.Settings=gtk
 
-org.freedesktop.impl.portal.Background=regolith
-org.freedesktop.impl.portal.Clipboard=regolith
-org.freedesktop.impl.portal.InputCapture=regolith
-org.freedesktop.impl.portal.RemoteDesktop=regolith
-org.freedesktop.impl.portal.Wallpaper=regolith
+org.freedesktop.impl.portal.Background=none
+org.freedesktop.impl.portal.Clipboard=none
+org.freedesktop.impl.portal.InputCapture=none
+org.freedesktop.impl.portal.RemoteDesktop=none
+org.freedesktop.impl.portal.Wallpaper=none

--- a/debian/control
+++ b/debian/control
@@ -27,11 +27,11 @@ Description: Regolith XDG Portal backend
 Package: xdg-desktop-portal-regolith-x11-config
 Architecture: any
 Depends:
-  xdg-desktop-portal-regolith
+  xdg-desktop-portal (>=1.20)
 Description: Regolith X11 XDG Portal configuration file
 
 Package: xdg-desktop-portal-regolith-wayland-config
 Architecture: any
 Depends:
-  xdg-desktop-portal-regolith
+  xdg-desktop-portal (>=1.20)
 Description: Regolith Wayland XDG Portal configuration file


### PR DESCRIPTION
This PR replaces the use of the no-op `xdg-desktop-portal-regolith` backend that was previously used to disable interfaces and uses the none keyword.

Fixes #19 